### PR TITLE
GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,41 @@
+name: 'wap'
+description: 'Package and upload your addons'
+inputs:
+  version:
+    description: 'The version to package and upload.'
+    required: true
+  config-path:
+    description: 'The path to your configuration file.'
+    required: false
+    default: "./.wap.yml"
+  release-type:
+    description: 'The type of release to make. Either "alpha", "beta", or "release".'
+    required: false
+    default: "alpha"
+  curseforge-token:
+    description: 'The value of your CurseForge API token.'
+    required: true
+  changelog-contents:
+    description: |
+      The contents of your changelog.
+
+      This input is optional. If it is provided, it must be used with changelog-type. Otherwise,
+      the changelog data will come from your configuration file.
+    required: false
+  changelog-type:
+    description: |
+      The format of your changelog contents. Either "markdown", "html", or "text".
+
+      This input is optional. If it is provided, it must be used with changelog-contents. Otherwise,
+      the changelog data will come from your configuration file.
+    required: false
+runs:
+  using: 'docker'
+  image: 'action/Dockerfile'
+  env:
+    WAP_VERSION: ${{ inputs.version }}
+    WAP_CONFIG_PATH: ${{ inputs.config-path }}
+    WAP_RELEASE_TYPE: ${{ inputs.release-type }}
+    WAP_CHANGELOG_TYPE: ${{ inputs.changelog-type }}
+    WAP_CHANGELOG_CONTENTS: ${{ inputs.changelog-contents }}
+    WAP_CURSEFORGE_TOKEN.: ${{ inputs.curseforge-token }}

--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.9.2-buster
+
+COPY action/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+wap package \
+  --version "$WAP_VERSION" \
+  --config-path "$WAP_CONFIG_PATH"
+
+if [[ -n $WAP_CHANGELOG_TYPE ]]; then
+    wap upload \
+      --version "$WAP_VERSION" \
+      --config-path "$WAP_CONFIG_PATH" \
+      --release-type "$WAP_RELEASE_TYPE" \
+      --curseforge-token "$WAP_CURSEFORGE_TOKEN" \
+      --changelog-type "$WAP_CHANGELOG_TYPE" \
+      --changelog-contents "$WAP_CHANGELOG_CONTENTS"
+else
+    wap upload \
+      --version "$WAP_VERSION" \
+      --config-path "$WAP_CONFIG_PATH" \
+      --release-type "$WAP_RELEASE_TYPE" \
+      --curseforge-token "$WAP_CURSEFORGE_TOKEN"
+fi


### PR DESCRIPTION
Untested GH actions support.

I'm not sure if I want to go through with this yet because the packages are not accessible to other steps in a job that uses this action.

Therefore, you couldn't do anything more with the packages, like use them to create a GH release asset.