### PR TITLE
Ensure UTF-8 encoding for file reading/writing

### DIFF
--- a/wap/changelog.py
+++ b/wap/changelog.py
@@ -48,7 +48,7 @@ class Changelog:
             )
             type = "text"
 
-        with path.open("r", encoding='utf-8') as file:
+        with path.open("r", encoding="utf-8") as file:
             contents = file.read()
 
         return cls(

--- a/wap/changelog.py
+++ b/wap/changelog.py
@@ -48,7 +48,7 @@ class Changelog:
             )
             type = "text"
 
-        with path.open("r") as file:
+        with path.open("r", encoding='utf-8') as file:
             contents = file.read()
 
         return cls(

--- a/wap/commands/quickstart.py
+++ b/wap/commands/quickstart.py
@@ -13,7 +13,7 @@ LATEST_RETAIL_VERSION = WoWVersion.from_dot_version("9.0.2")
 
 
 def write_changelog(path: Path, name: str) -> None:
-    with path.open("w", encoding='utf-8') as changelog_file:
+    with path.open("w", encoding="utf-8") as changelog_file:
         changelog_file.write(f"# {name} Changelog\n\n")
         changelog_file.write(
             "This file is used by *wap* when you upload to Curseforge. It should "
@@ -25,7 +25,7 @@ def write_changelog(path: Path, name: str) -> None:
 
 
 def write_readme(path: Path, name: str) -> None:
-    with path.open("w", encoding='utf-8') as readme_file:
+    with path.open("w", encoding="utf-8") as readme_file:
         readme_file.write(f"# {name}\n\n")
         readme_file.write(
             "(This file is not required to run *wap*. It is here as a suggestion to "
@@ -51,7 +51,7 @@ def write_readme(path: Path, name: str) -> None:
 
 
 def write_lua_file(path: Path, name: str) -> None:
-    with path.open("w", encoding='utf-8') as lua_file:
+    with path.open("w", encoding="utf-8") as lua_file:
         lua_file.write("-- Your code can go here.\n")
         lua_file.write("-- Here's something to get you started,\n")
         lua_file.write("-- but you can erase it if you wish.\n\n")

--- a/wap/commands/quickstart.py
+++ b/wap/commands/quickstart.py
@@ -13,7 +13,7 @@ LATEST_RETAIL_VERSION = WoWVersion.from_dot_version("9.0.2")
 
 
 def write_changelog(path: Path, name: str) -> None:
-    with path.open("w") as changelog_file:
+    with path.open("w", encoding='utf-8') as changelog_file:
         changelog_file.write(f"# {name} Changelog\n\n")
         changelog_file.write(
             "This file is used by *wap* when you upload to Curseforge. It should "
@@ -25,7 +25,7 @@ def write_changelog(path: Path, name: str) -> None:
 
 
 def write_readme(path: Path, name: str) -> None:
-    with path.open("w") as readme_file:
+    with path.open("w", encoding='utf-8') as readme_file:
         readme_file.write(f"# {name}\n\n")
         readme_file.write(
             "(This file is not required to run *wap*. It is here as a suggestion to "
@@ -51,7 +51,7 @@ def write_readme(path: Path, name: str) -> None:
 
 
 def write_lua_file(path: Path, name: str) -> None:
-    with path.open("w") as lua_file:
+    with path.open("w", encoding='utf-8') as lua_file:
         lua_file.write("-- Your code can go here.\n")
         lua_file.write("-- Here's something to get you started,\n")
         lua_file.write("-- but you can erase it if you wish.\n\n")

--- a/wap/config.py
+++ b/wap/config.py
@@ -343,11 +343,11 @@ class Config(YamlType["Config", Mapping[str, Any]]):
         if not path.is_file():
             raise ConfigFileException(f'No such config file "{path}"')
 
-        with path.open("r") as file:
+        with path.open("r", encoding='utf-8') as file:
             contents = file.read()
 
         return cls.from_yaml(yaml=contents, label=str(path))
 
     def to_path(self, path: Path) -> None:
-        with path.open("w") as file:
+        with path.open("w", encoding='utf-8') as file:
             file.write(self.to_yaml())

--- a/wap/config.py
+++ b/wap/config.py
@@ -343,11 +343,11 @@ class Config(YamlType["Config", Mapping[str, Any]]):
         if not path.is_file():
             raise ConfigFileException(f'No such config file "{path}"')
 
-        with path.open("r", encoding='utf-8') as file:
+        with path.open("r", encoding="utf-8") as file:
             contents = file.read()
 
         return cls.from_yaml(yaml=contents, label=str(path))
 
     def to_path(self, path: Path) -> None:
-        with path.open("w", encoding='utf-8') as file:
+        with path.open("w", encoding="utf-8") as file:
             file.write(self.to_yaml())

--- a/wap/toc.py
+++ b/wap/toc.py
@@ -135,6 +135,6 @@ def write_toc(
         *[_create_file_line(file) for file in toc_config.files],
     ]
 
-    with write_path.open("w") as toc_file:
+    with write_path.open("w", encoding='utf-8') as toc_file:
         for line in lines:
             toc_file.write(line)

--- a/wap/toc.py
+++ b/wap/toc.py
@@ -135,6 +135,6 @@ def write_toc(
         *[_create_file_line(file) for file in toc_config.files],
     ]
 
-    with write_path.open("w", encoding='utf-8') as toc_file:
+    with write_path.open("w", encoding="utf-8") as toc_file:
         for line in lines:
             toc_file.write(line)


### PR DESCRIPTION
This PR changed the way files are opened to make sure they are interpreted/written using UTF-8 encoding.
Previously wap assumed the default encoding of the system (The Windows-1252 ASCII extension for example)

This caused some issues with non-ASCII characters while reading the .wap.yml file and while generating the resulting .toc file(s).
For example while writing Russian addon descriptions: 
`Notes-ruRU: "Простой интерфейс"`

The above text would cause the following error while packaging the addon:
```
Traceback (most recent call last):
  File "d:\python\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "d:\python\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "D:\Python\Python39\Scripts\wap.exe\__main__.py", line 7, in <module>
  File "d:\python\python39\lib\site-packages\wap\__main__.py", line 15, in main
    exit_code = base.main(standalone_mode=False)
  File "d:\python\python39\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "d:\python\python39\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "d:\python\python39\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "d:\python\python39\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "d:\python\python39\lib\site-packages\wap\commands\package.py", line 46, in package
    config = Config.from_path(config_path)
  File "d:\python\python39\lib\site-packages\wap\config.py", line 347, in from_path
    contents = file.read()
  File "d:\python\python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 481: character maps to <undefined>
```

Forcing the file operations to use UTF-8 avoids these issues.